### PR TITLE
Fix: Can not display account imported after immediate reload

### DIFF
--- a/src/utils/casper/user.ts
+++ b/src/utils/casper/user.ts
@@ -262,6 +262,7 @@ export class UserService {
 
     user.addLegacyWallet(wallet, new WalletDescriptor(name));
     const walletInfo = user.getWalletInfo(wallet.getReferenceKey());
+    await this.prepareStorageData();
 
     return walletInfo;
   };


### PR DESCRIPTION
### What does PR do?
- Save user instance to local storage after importing account