### PR TITLE
Feat: Tooltip for account hash

### DIFF
--- a/src/components/Common/MiddleTruncatedText/index.tsx
+++ b/src/components/Common/MiddleTruncatedText/index.tsx
@@ -5,9 +5,7 @@ import {
   Text,
   TextProps,
   Tooltip,
-  useClipboard,
 } from '@chakra-ui/react';
-import { useTranslation } from 'react-i18next';
 
 import { startAndEnd } from '@/utils/format';
 
@@ -25,17 +23,7 @@ const MiddleTruncatedText = ({
   endLength = 7,
   textProps,
   placement,
-  isCopy,
 }: Props) => {
-  const { t } = useTranslation();
-  const { onCopy, hasCopied } = useClipboard(value || '');
-
-  const handleOnClick = () => {
-    if (isCopy) {
-      onCopy();
-    }
-  };
-
   if (!value) {
     return null;
   }
@@ -45,19 +33,7 @@ const MiddleTruncatedText = ({
 
   return (
     <Tooltip label={value} placement={placement}>
-      {hasCopied ? (
-        <Text {...textProps} color={'green'}>
-          {t('copied')}
-        </Text>
-      ) : (
-        <Text
-          cursor={isCopy ? 'pointer' : 'auto'}
-          {...textProps}
-          onClick={handleOnClick}
-        >
-          {startAndEnd(value, startLength, endLength)}
-        </Text>
-      )}
+      <Text {...textProps}>{startAndEnd(value, startLength, endLength)}</Text>
     </Tooltip>
   );
 };

--- a/src/components/Common/MiddleTruncatedText/index.tsx
+++ b/src/components/Common/MiddleTruncatedText/index.tsx
@@ -5,7 +5,9 @@ import {
   Text,
   TextProps,
   Tooltip,
+  useClipboard,
 } from '@chakra-ui/react';
+import { useTranslation } from 'react-i18next';
 
 import { startAndEnd } from '@/utils/format';
 
@@ -15,23 +17,47 @@ type Props = {
   endLength?: number;
   textProps?: TextProps;
   placement?: PlacementWithLogical;
+  isCopy?: boolean;
 };
 const MiddleTruncatedText = ({
   value,
   startLength = 5,
-  endLength = 4,
+  endLength = 7,
   textProps,
   placement,
+  isCopy,
 }: Props) => {
+  const { t } = useTranslation();
+  const { onCopy, hasCopied } = useClipboard(value || '');
+
+  const handleOnClick = () => {
+    if (isCopy) {
+      onCopy();
+    }
+  };
+
   if (!value) {
     return null;
   }
   if (startLength + endLength >= value.length) {
     return <Text {...textProps}>{value}</Text>;
   }
+
   return (
     <Tooltip label={value} placement={placement}>
-      <Text {...textProps}>{startAndEnd(value, startLength, endLength)}</Text>
+      {hasCopied ? (
+        <Text {...textProps} color={'green'}>
+          {t('copied')}
+        </Text>
+      ) : (
+        <Text
+          cursor={isCopy ? 'pointer' : 'auto'}
+          {...textProps}
+          onClick={handleOnClick}
+        >
+          {startAndEnd(value, startLength, endLength)}
+        </Text>
+      )}
     </Tooltip>
   );
 };

--- a/src/modules/NFTMarket/NFTMarketDetail/NFTInfoSection.tsx
+++ b/src/modules/NFTMarket/NFTMarketDetail/NFTInfoSection.tsx
@@ -1,4 +1,5 @@
-import { Box, Flex, Tag, Text } from '@chakra-ui/react';
+import { InfoOutlineIcon } from '@chakra-ui/icons';
+import { Box, Flex, Tag, Text, Tooltip } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
 
 import BuyModalButton from '../components/BuyModalButton';
@@ -43,7 +44,12 @@ const NFTInfoSection = ({ nft }: Props) => {
             <GradientAvatar name={nft?.sellerAccountHash || ''} size={40} />
           </Box>
           <Box ml="2">
-            <Text color="gray">Current owner</Text>
+            <Flex alignItems={'center'}>
+              <Text color="gray">{t('current_owner')}</Text>
+              <Tooltip label={t('account_hash')}>
+                <InfoOutlineIcon ml="2" color="gray" />
+              </Tooltip>
+            </Flex>
             <MiddleTruncatedText value={nft?.sellerAccountHash} endLength={8} />
           </Box>
         </Flex>

--- a/src/modules/Staking/components/ListRewards/index.tsx
+++ b/src/modules/Staking/components/ListRewards/index.tsx
@@ -11,6 +11,7 @@ import { IValidator, useGetValidators } from '@/hooks/queries/useGetValidators';
 import { useAccount } from '@/hooks/useAccount';
 import i18n from '@/i18n';
 import { DelegatorReward } from '@/services/cspr/delegator/type';
+import { toCSPR } from '@/utils/currency';
 import { formatReadDate } from '@/utils/date';
 
 type ListRewardsProps = FlexProps;
@@ -63,7 +64,7 @@ const ListRewards = (props: ListRewardsProps) => {
     }),
     columnHelper.accessor('amount', {
       cell: (info) => {
-        return <AssetText value={info.getValue()} asset="CSPR" />;
+        return <AssetText value={toCSPR(info.getValue())} asset="CSPR" />;
       },
       header: () => (
         <Text display={{ base: 'none', md: 'block' }}>{i18n.t('amount')}</Text>

--- a/src/modules/core/AccountSidebar/index.tsx
+++ b/src/modules/core/AccountSidebar/index.tsx
@@ -48,6 +48,7 @@ const AccountSidebar = () => {
                 <MiddleTruncatedText
                   textProps={{ fontSize: '12px', fontWeight: 400 }}
                   value={publicKey}
+                  isCopy
                 />
               </Box>
               <MyAccount isButton />

--- a/src/modules/core/AccountSidebar/index.tsx
+++ b/src/modules/core/AccountSidebar/index.tsx
@@ -48,7 +48,6 @@ const AccountSidebar = () => {
                 <MiddleTruncatedText
                   textProps={{ fontSize: '12px', fontWeight: 400 }}
                   value={publicKey}
-                  isCopy
                 />
               </Box>
               <MyAccount isButton />

--- a/src/public/locales/en/common.json
+++ b/src/public/locales/en/common.json
@@ -202,5 +202,8 @@
   "nft_not_listed": "This NFT collection has not supported for listing. Please contact our Admin for more details.",
   "nft_can_list": "This NFT collection has supported for listing. You can list your NFT now.",
   "switch_account": "Switch your account",
-  "write_down_your_recovery_phrase": "Write down your recovery phrase and keep it in a safe place"
+  "write_down_your_recovery_phrase": "Write down your recovery phrase and keep it in a safe place",
+  "current_owner": "Current owner",
+  "account_hash": "Owner account hash",
+  "copied": "Copied!"
 }


### PR DESCRIPTION
### Summary (Please recap what you changed or fixed)
- Tooltip for account hash
- Add copy attribute for MiddleTruncatedText

<img width="297" alt="image" src="https://github.com/CasperDash/casperdash-web/assets/20489407/54c27369-addf-4581-966d-b30b3d846d45">

<img width="1369" alt="image" src="https://github.com/CasperDash/casperdash-web/assets/20489407/86dc2489-2bb5-4196-90bc-dc770d505c68">

### Checklist (If you won't pass this checklist please comment why)

- [x] I removed all commented or unnecessary code.
- [x] Provide the screenshots due to UI changed or bug fixed
- [ ] My code has covered these test cases (please list down your tested cases):
